### PR TITLE
Update TSCC bashrc to latest Anaconda distribution

### DIFF
--- a/bashrc/tscc_bash_settings_current
+++ b/bashrc/tscc_bash_settings_current
@@ -61,7 +61,7 @@ export HDF5_DIR=/home/yeo-lab/software
 
 
 # added by Anaconda 1.9.1 installer
-export PATH="/projects/ps-yeolab/software/anaconda/bin:~/bin:$PATH"
+export PATH="/projects/ps-yeolab/software/anaconda-2.1.0_2015-01-20/bin:~/bin:$PATH"
 export PYTHONPATH=
 
 export PYTHONPATH='/opt/scar/lib/':$PYTHONPATH


### PR DESCRIPTION
Because of the python craziness, I've re-installed the latest version of Anaconda on TSCC. This pull request changes the location of the Anaconda path in the `bashrc/tscc_bash_settings_current` file.

Everyone will need to re-create their environments, using the [instructions](http://yeolab.github.io/welcome/tscc.html#make-a-virtual-environment-on-tscc) from the welcome page. I've tried to make `base` as complete as possible, with the current master versions of `clipper`, `gscripts` and `flotilla` so people can get started right away. Please let me know if there are any packages missing.