### PR TITLE
Add a #!/usr/bin/env python line at the top to specifically call python

### DIFF
--- a/gscripts/mirna/miR_splitter.py
+++ b/gscripts/mirna/miR_splitter.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+
 __author__ = 'lovci'
 
 import argparse


### PR DESCRIPTION
There's some error going on:

```
ERROR 10:10:14,576 FunctionEdge - Contents of /oasis/tscc/scratch/jbrought/mirpipe2/analysis/v11_output/IC11.R07_L7_6.polyATrim.adapterTrim.groom.cel-lin-4-3p-star.fastq

.out:

/projects/ps-yeolab/software/anaconda-2.1.0_2015-01-20/envs/jbrought_custom/bin/miR_splitter.py: line 1: __author__: command not found

import: unable to open X server `' @ import.c/ImportImageCommand/359.

import: unable to open X server `' @ import.c/ImportImageCommand/359.

import: unable to open X server `' @ import.c/ImportImageCommand/359.

/projects/ps-yeolab/software/anaconda-2.1.0_2015-01-20/envs/jbrought_custom/bin/miR_splitter.py: line 7: syntax error near unexpected token `('

/projects/ps-yeolab/software/anaconda-2.1.0_2015-01-20/envs/jbrought_custom/bin/miR_splitter.py: line 7: `def construct_cutadapt_call(miRNA_seq, miRNA_id, fastq, output,

 **kwargs):' 
```

I suspect it is because there was no `#!/user/bin/env python` at the top of the file, so the computer didn't realize it needs to use python.