### PR TITLE
remove reptitive regions on paired-end

### DIFF
--- a/bashrc/tscc_bash_settings_current
+++ b/bashrc/tscc_bash_settings_current
@@ -22,7 +22,7 @@ export LD_RUN_PATH=/home/yeo-lab/software/lib:$LD_RUN_PATH
 export GNUPLOT_DEFAULT_GDFONT=LiberationSans-Regular
 
 export BOWTIE_INDEXES=/projects/ps-yeolab/genomes/bowtie_index
-export BOWTIE2_INDEXES=/projects/ps-yeolab/genomes/bowtie_index
+export BOWTIE2_INDEXES=/projects/ps-yeolab/genomes/bowtie2_indexes
 
 #GHC
 export LD_RUN_PATH=/home/yeo-lab/software/ghc/lib:$LD_RUN_PATH 

--- a/bashrc/tscc_bash_settings_current
+++ b/bashrc/tscc_bash_settings_current
@@ -17,6 +17,7 @@ export LD_LIBRARY_PATH=/home/yeo-lab/software/lib:$LD_LIBRARY_PATH
 export LD_LIBRARY_PATH=/home/yeo-lab/software/linux/gcc/dyn/x86_64/rel/lib:$LD_LIBRARY_PATH
 
 export LD_RUN_PATH=/home/yeo-lab/software/lib:$LD_RUN_PATH 
+export PATH=/home/yeo-lab/software/STAR/source:$PATH
 
 #export GDFONTPATH=${SERVER}/yeolab/Software/liberation-fonts-ttf-1.06.0.20100721
 export GNUPLOT_DEFAULT_GDFONT=LiberationSans-Regular

--- a/qscripts/analyze_rna_seq.scala
+++ b/qscripts/analyze_rna_seq.scala
@@ -50,7 +50,7 @@ class AnalyzeRNASeq extends QScript {
   }
 
   case class mapRepetitiveRegions(noAdapterFastq: File, filteredResults: File, filteredFastq: File, 
-    fastqPair: File = null, originalFastq: File, originalFastqPair: File) extends MapRepetitiveRegions2 {
+    fastqPair: File = null, originalFastqPair) extends MapRepetitiveRegions2 {
     override def shortDescription = "MapRepetitiveRegions"
 
     this.inFastq = noAdapterFastq

--- a/qscripts/analyze_rna_seq.scala
+++ b/qscripts/analyze_rna_seq.scala
@@ -217,10 +217,8 @@ class AnalyzeRNASeq extends QScript {
 
     // run if stringent
 
-    val outDir = swapExt(fastqFile, ".fastq", "_trim_galore")
-
-    val trimmedFastq = outDir + "/" + swapExt(fastqFile, ".fastq", "_trimmed.fastq")
-    val trimmedFastqPair = outDir + "/" + swapExt(fastqPair, ".fastq", "_trimmed.fastq")
+    val trimmedFastq = swapExt(fastqFile, ".fastq.gz", "_trimmed.fastq")
+    val trimmedFastqPair = swapExt(fastqPair, ".fastq.gz", "_trimmed.fastq")
 
     val filteredFastq = swapExt(fastqFile, ".fastq", ".polyATrim.adapterTrim.rmRep.fastq").replace("R1", "R%")
     val filteredFastqPair = swapExt(fastqFile, ".fastq", ".polyATrim.adapterTrim.rmRep.fastq").replace("R2", "R%")

--- a/qscripts/analyze_rna_seq.scala
+++ b/qscripts/analyze_rna_seq.scala
@@ -56,14 +56,15 @@ class AnalyzeRNASeq extends QScript {
 
     var paired = noAdapterFastq != null
     if (paired){
-      filteredFastq = swapExt(filteredFastq, ".fastq", ".fastq").replace("1", "%")
+      outFastq = swapExt(filteredFastq, ".fastq", ".fastq").replace("1", "%")
+    } else{
+      outFastq = filteredFastq
     }
 
     this.inFastq = noAdapterFastq
     this.inFastqPair = fastqPair
     this.outRepetitive = filteredResults
-    this.outNoRepetitive = filteredFastq
-    this.outNoRepetitivePair = filteredFastqPair
+    this.outNoRepetitive = outFastq
     this.isIntermediate = false
     this.fakeVariable = dummy
   }

--- a/qscripts/analyze_rna_seq.scala
+++ b/qscripts/analyze_rna_seq.scala
@@ -37,22 +37,9 @@ class AnalyzeRNASeq extends QScript {
   @Argument(doc = "reads are single ended", shortName = "single_end", fullName = "single_end", required = false)
   var singleEnd: Boolean = true
 
-<<<<<<< HEAD
   @Argument(doc = "Use trim_galore instead of cutadapt (required if '--strict' is provided and '--single_end' is not, i.e. for strict processing of paired-end reads)", 
     shortName = "yes_trim_galore", fullName = "yes_trim_galore", required = false)
   var yesTrimGalore: Boolean = true
-=======
-  @Argument(doc = "Use trim_galore instead of cutadapt (required if '--strict'"
-   "is provided and '--single_end' is not, i.e. for strict processing of paired-end reads)", 
-    shortName = "trim_galore", fullName = "trim_galore", required = false)
-  var trimGalore: Boolean = true
-
-  if ((trimGalore && strict) && (singleEnd == false)){
-    println("If the reads are paired-end and run with '--strict', then '--trim_galore' must be provided!\n"
-      "Otherwise your trimmed paired end reads won't retain their paired-end-ness and you'll have a bad time :(")
-    System.exit(1)
-  }
->>>>>>> Add trimgalore
 
   case class sortSam(inSam: File, outBam: File, sortOrderP: SortOrder) extends SortSam {
     override def shortDescription = "sortSam"
@@ -227,12 +214,14 @@ class AnalyzeRNASeq extends QScript {
   }
 
 
-  def stringentJobsTrimGalore(fastqFile: File, fastqPair: File = null, paired: Boolean = false): (File, File) = {
+  def stringentJobsTrimGalore(fastqFile: File, fastqPair: File = null): (File, File) = {
 
     // run if stringent
 
-    val trimmedFastq = swapExt(fastqFile, ".fastq.gz", "_val_1.fq")
-    val trimmedFastqPair = swapExt(fastqPair, ".fastq.gz", "_val_2.fq")
+    val outDir = swapExt(fastqFile, ".fastq", "_trim_galore")
+
+    val trimmedFastq = outDir + "/" + swapExt(fastqFile, ".fastq", "._val_1.fq")
+    val trimmedFastqPair = outDir + "/" + swapExt(fastqPair, ".fastq", "._val_2.fq")
 
     val filteredFastq = swapExt(fastqFile, ".fastq", ".polyATrim.adapterTrim.rmRep.fastq")
     val filteredFastqPair = swapExt(fastqPair, ".fastq", ".polyATrim.adapterTrim.rmRep.fastq")
@@ -253,6 +242,7 @@ class AnalyzeRNASeq extends QScript {
 
 
     return (filteredFastq, filteredFastqPair)
+
   }
 
   def makeBigWig(inBam: File, species: String): (File, File) = {

--- a/qscripts/analyze_rna_seq.scala
+++ b/qscripts/analyze_rna_seq.scala
@@ -218,8 +218,8 @@ class AnalyzeRNASeq extends QScript {
 
     // run if stringent
 
-    val trimmedFastq = swapExt(fastqFile, ".fastq.gz", "_trimmed.fastq")
-    val trimmedFastqPair = swapExt(fastqPair, ".fastq.gz", "_trimmed.fastq")
+    val trimmedFastq = swapExt(fastqFile, ".fastq.gz", "_trimmed.fq")
+    val trimmedFastqPair = swapExt(fastqPair, ".fastq.gz", "_trimmed.fq")
 
     val filteredFastq = swapExt(fastqFile, ".fastq", ".polyATrim.adapterTrim.rmRep.fastq")
     val filteredFastqPair = swapExt(fastqPair, ".fastq", ".polyATrim.adapterTrim.rmRep.fastq")

--- a/qscripts/analyze_rna_seq.scala
+++ b/qscripts/analyze_rna_seq.scala
@@ -50,14 +50,16 @@ class AnalyzeRNASeq extends QScript {
   }
 
   case class mapRepetitiveRegions(noAdapterFastq: File, filteredResults: File, filteredFastq: File, 
-    fastqPair: File = null, originalFastq: File, originalFastqPair: File = null, dummy : File) extends MapRepetitiveRegions2 {
+    fastqPair: File = null, filteredFastqPair: File = null, originalFastq: File, 
+    originalFastqPair: File = null, dummy : File) extends MapRepetitiveRegions2 {
     override def shortDescription = "MapRepetitiveRegions"
 
     this.inFastq = noAdapterFastq
     this.inFastqPair = fastqPair
     this.outRepetitive = filteredResults
     this.outNoRepetitive = filteredFastq
-    this.isIntermediate = true
+    this.outnoRepetitivePair = filteredFastqPair
+    this.isIntermediate = false
     this.fakeVariable = dummy
   }
 
@@ -189,7 +191,7 @@ class AnalyzeRNASeq extends QScript {
     val noPolyAFastq = swapExt(fastqFile, ".fastq", ".polyATrim.fastq")
     val noPolyAReport = swapExt(noPolyAFastq, ".fastq", ".metrics")
     val noAdapterFastq = swapExt(noPolyAFastq, ".fastq", ".adapterTrim.fastq")
-    val filteredFastq = swapExt(noAdapterFastq, ".fastq", ".rmRep.fastq").replace("R1", "R%")
+    val filteredFastq = swapExt(noAdapterFastq, ".fastq", ".rmRep.fastq")
     val adapterReport = swapExt(noAdapterFastq, ".fastq", ".metrics")
     val filtered_results = swapExt(filteredFastq, ".fastq", ".metrics")
     //filters out adapter reads

--- a/qscripts/analyze_rna_seq.scala
+++ b/qscripts/analyze_rna_seq.scala
@@ -228,8 +228,8 @@ class AnalyzeRNASeq extends QScript {
     val trimmedFastq = swapExt(fastqFile, ".fastq.gz", "_val_1.fq")
     if (fastqPair != null){
       val trimmedFastqPair = swapExt(fastqPair, ".fastq.gz", "_val_2.fq")
-    } else{
-      val trimmedFastqPair: File = null
+    } else {
+      val trimmedFastqPair = fastqPair
     }
 
     val filteredFastq = swapExt(fastqFile, ".fastq", ".polyATrim.adapterTrim.rmRep.fastq")

--- a/qscripts/analyze_rna_seq.scala
+++ b/qscripts/analyze_rna_seq.scala
@@ -247,8 +247,7 @@ class AnalyzeRNASeq extends QScript {
       add(mapRepetitiveRegions(trimmedFastq=trimmedFastq, filteredResults=repetitiveAligned, filteredFastq=filteredFastq, 
       dummy=dummy, isPaired=paired))
       add(new FastQC(filteredFastq))
-      val filteredFastq: File = _
-
+      val filteredFastq: File = null
     }
 
 

--- a/qscripts/analyze_rna_seq.scala
+++ b/qscripts/analyze_rna_seq.scala
@@ -233,7 +233,8 @@ class AnalyzeRNASeq extends QScript {
 
     add(trimGalore(fastqFile, fastqPair, adapter, dummy, isPaired=paired))
 
-    if (fastqPair != null){
+    // filter out adapter reads
+    if (paired){
       val trimmedFastq = swapExt(fastqFile, ".fastq.gz", "_val_1.fq")
       val trimmedFastqPair = swapExt(fastqPair, ".fastq.gz", "_val_2.fq")
       val filteredFastqPair = swapExt(fastqPair, ".fastq", ".polyATrim.adapterTrim.rmRep.fastq")
@@ -250,13 +251,7 @@ class AnalyzeRNASeq extends QScript {
       val filteredFastqPair = swapExt(fastqFile, ".fastq.gz", ".fake_fastq_pair.fastq.gz")
     }
 
-
-    //filters out adapter reads
-
     add(countRepetitiveRegions(bam=repetitiveAligned, metrics=repetitiveCounts))
-
-    // Question: trim_galore can run fastqc on the 
-
     return (filteredFastq, filteredFastqPair)
   }
 

--- a/qscripts/analyze_rna_seq.scala
+++ b/qscripts/analyze_rna_seq.scala
@@ -206,7 +206,7 @@ class AnalyzeRNASeq extends QScript {
   }
 
 
-  def stringentJobsTrimGalore(fastqFile: File, fastqPair: File = null, adapter: List[String] = Nil): (File, File) = {
+  def stringentJobsTrimGalore(fastqFile: File, fastqPair: File = null): (File, File) = {
 
     // run if stringent
 
@@ -217,15 +217,9 @@ class AnalyzeRNASeq extends QScript {
 
     val filteredFastq = swapExt(fastqFile, ".fastq", ".polyATrim.adapterTrim.rmRep.fastq").replace("R1", "R%")
     val filteredFastqPair = swapExt(fastqFile, ".fastq", ".polyATrim.adapterTrim.rmRep.fastq").replace("R2", "R%")
-
-<<<<<<< HEAD
     val filteredResults = swapExt(filteredFastq, ".fastq", ".metrics")
     val dummy: File = swapExt(fastqFile, ".fastq", ".dummy")
-=======
-    val filtered_results = swapExt(filteredFastq, ".fastq", ".metrics")
-    //filters out adapter reads
     add(trimGalore(fastqFile = fastqFile, fastqPair=fastqPair, adapter = adapter))
->>>>>>> fix up call to trimgalore
 
     //filters out adapter reads
     add(trimGalore(fastqFile, fastqPair, adapter, dummy, isPaired=paired))
@@ -333,7 +327,7 @@ class AnalyzeRNASeq extends QScript {
           if (fastqPair == null){
             if (strict) {
               if (yesTrimGalore){
-                 var filteredFiles = stringentJobsTrimGalore(fastqFile, adapter=adapter)
+                 var filteredFiles = stringentJobsTrimGalore(fastqFile)
                  filteredFastq = filteredFiles._1
                 } else{
                  filteredFastq = stringentJobs(fastqFile)
@@ -343,7 +337,7 @@ class AnalyzeRNASeq extends QScript {
             }
           } else {
             if (strict) {
-              var filteredFiles = stringentJobsTrimGalore(fastqFile, fastqPair, adapter=adapter)
+              var filteredFiles = stringentJobsTrimGalore(fastqFile, fastqPair)
               filteredFastq = filteredFiles._1
               filteredFastqPair = filteredFiles._2
             } else {

--- a/qscripts/analyze_rna_seq.scala
+++ b/qscripts/analyze_rna_seq.scala
@@ -226,8 +226,10 @@ class AnalyzeRNASeq extends QScript {
     // run if stringent
 
     val trimmedFastq = swapExt(fastqFile, ".fastq.gz", "_val_1.fq")
-    if (trimmedFastqPair != null){
+    if (fastqPair != null){
       val trimmedFastqPair = swapExt(fastqPair, ".fastq.gz", "_val_2.fq")
+    } else{
+      var trimmedFastqPair: File = null
     }
 
     val filteredFastq = swapExt(fastqFile, ".fastq", ".polyATrim.adapterTrim.rmRep.fastq")

--- a/qscripts/analyze_rna_seq.scala
+++ b/qscripts/analyze_rna_seq.scala
@@ -212,8 +212,8 @@ class AnalyzeRNASeq extends QScript {
 
     val outDir = swapExt(fastqFile, ".fastq", "_trim_galore")
 
-    val trimmedFastq = outDir + "/" + swapExt(fastqFile, ".fastq", "._val_1.fq")
-    val trimmedFastqPair = outDir + "/" + swapExt(fastqPair, ".fastq", "._val_2.fq")
+    val trimmedFastq = outDir + "/" + swapExt(fastqFile, ".fastq", "_trimmed.fastq")
+    val trimmedFastqPair = outDir + "/" + swapExt(fastqPair, ".fastq", "_trimmed.fastq")
 
     val filteredFastq = swapExt(fastqFile, ".fastq", ".polyATrim.adapterTrim.rmRep.fastq").replace("R1", "R%")
     val filteredFastqPair = swapExt(fastqFile, ".fastq", ".polyATrim.adapterTrim.rmRep.fastq").replace("R2", "R%")

--- a/qscripts/analyze_rna_seq.scala
+++ b/qscripts/analyze_rna_seq.scala
@@ -226,7 +226,9 @@ class AnalyzeRNASeq extends QScript {
     // run if stringent
 
     val trimmedFastq = swapExt(fastqFile, ".fastq.gz", "_val_1.fq")
-    val trimmedFastqPair = swapExt(fastqPair, ".fastq.gz", "_val_2.fq")
+    if (trimmedFastqPair != null){
+      val trimmedFastqPair = swapExt(fastqPair, ".fastq.gz", "_val_2.fq")
+    }
 
     val filteredFastq = swapExt(fastqFile, ".fastq", ".polyATrim.adapterTrim.rmRep.fastq")
     val filteredFastqPair = swapExt(fastqPair, ".fastq", ".polyATrim.adapterTrim.rmRep.fastq")

--- a/qscripts/analyze_rna_seq.scala
+++ b/qscripts/analyze_rna_seq.scala
@@ -214,7 +214,7 @@ class AnalyzeRNASeq extends QScript {
 
     add(mapRepetitiveRegions(noAdapterFastq, repetitiveAligned, filteredFastq, dummy=dummy, 
       isPaired=false))
-    add(countRepetitiveRegions(inBam=repetitiveAligned, outFile=repetitiveCounts))
+    add(countRepetitiveRegions(bam=repetitiveAligned, metrics=repetitiveCounts))
     add(new FastQC(filteredFastq))
 
     return filteredFastq
@@ -242,7 +242,7 @@ class AnalyzeRNASeq extends QScript {
     add(mapRepetitiveRegions(trimmedFastq=trimmedFastq, filteredResults=repetitiveAligned, filteredFastq=filteredFastq, 
     trimmedFastqPair=trimmedFastqPair, filteredFastqPair=filteredFastqPair,
       dummy=dummy, isPaired=paired))
-    add(countRepetitiveRegions(inBam=repetitiveAligned, outFile=repetitiveCounts))
+    add(countRepetitiveRegions(bam=repetitiveAligned, metrics=repetitiveCounts))
 
     // Question: trim_galore can run fastqc on the 
     add(new FastQC(filteredFastq))

--- a/qscripts/analyze_rna_seq.scala
+++ b/qscripts/analyze_rna_seq.scala
@@ -247,7 +247,7 @@ class AnalyzeRNASeq extends QScript {
       add(mapRepetitiveRegions(trimmedFastq=trimmedFastq, filteredResults=repetitiveAligned, filteredFastq=filteredFastq, 
       dummy=dummy, isPaired=paired))
       add(new FastQC(filteredFastq))
-      val filteredFastq = swapExt(fastqFile, ".fastq.gz", ".fake_fastq_pair.fastq.gz")
+      val filteredFastqPair = swapExt(fastqFile, ".fastq.gz", ".fake_fastq_pair.fastq.gz")
     }
 
 

--- a/qscripts/analyze_rna_seq.scala
+++ b/qscripts/analyze_rna_seq.scala
@@ -68,6 +68,11 @@ class AnalyzeRNASeq extends QScript {
     this.paired = isPaired
   }
 
+  case class countRepetitiveRegions(bam: File, metrics: File) extends CountRepetitiveRegions{
+    this.inBam = bam
+    this.outFile = metrics
+  }
+
   case class genomeCoverageBed(input: File, outBed: File, cur_strand: String, species: String) extends GenomeCoverageBed {
     this.inBam = input
     this.genomeSize = chromSizeLocation(species)
@@ -209,7 +214,7 @@ class AnalyzeRNASeq extends QScript {
 
     add(mapRepetitiveRegions(noAdapterFastq, repetitiveAligned, filteredFastq, dummy=dummy, 
       isPaired=false))
-    add(CountRepetitiveRegions(inBam=repetitiveAligned, outFile=repetitiveCounts))
+    add(countRepetitiveRegions(inBam=repetitiveAligned, outFile=repetitiveCounts))
     add(new FastQC(filteredFastq))
 
     return filteredFastq
@@ -237,7 +242,7 @@ class AnalyzeRNASeq extends QScript {
     add(mapRepetitiveRegions(trimmedFastq=trimmedFastq, filteredResults=repetitiveAligned, filteredFastq=filteredFastq, 
     trimmedFastqPair=trimmedFastqPair, filteredFastqPair=filteredFastqPair,
       dummy=dummy, isPaired=paired))
-    add(CountRepetitiveRegions(inBam=repetitiveAligned, outFile=repetitiveCounts))
+    add(countRepetitiveRegions(inBam=repetitiveAligned, outFile=repetitiveCounts))
 
     // Question: trim_galore can run fastqc on the 
     add(new FastQC(filteredFastq))

--- a/qscripts/analyze_rna_seq.scala
+++ b/qscripts/analyze_rna_seq.scala
@@ -58,7 +58,7 @@ class AnalyzeRNASeq extends QScript {
     this.outRepetitive = filteredResults
     this.outNoRepetitive = filteredFastq
     this.isIntermediate = true
-    this.dummy = dummy
+    this.fakeVariable = dummy
   }
 
   case class genomeCoverageBed(input: File, outBed: File, cur_strand: String, species: String) extends GenomeCoverageBed {

--- a/qscripts/analyze_rna_seq.scala
+++ b/qscripts/analyze_rna_seq.scala
@@ -63,7 +63,7 @@ class AnalyzeRNASeq extends QScript {
     this.inFastqPair = fastqPair
     this.outRepetitive = filteredResults
     this.outNoRepetitive = filteredFastq
-    this.outnoRepetitivePair = filteredFastqPair
+    this.outNoRepetitivePair = filteredFastqPair
     this.isIntermediate = false
     this.fakeVariable = dummy
   }

--- a/qscripts/analyze_rna_seq.scala
+++ b/qscripts/analyze_rna_seq.scala
@@ -218,8 +218,8 @@ class AnalyzeRNASeq extends QScript {
 
     // run if stringent
 
-    val trimmedFastq = swapExt(fastqFile, ".fastq.gz", "_trimmed.fq")
-    val trimmedFastqPair = swapExt(fastqPair, ".fastq.gz", "_trimmed.fq")
+    val trimmedFastq = swapExt(fastqFile, ".fastq.gz", "_val_1.fq")
+    val trimmedFastqPair = swapExt(fastqPair, ".fastq.gz", "_val_2.fq")
 
     val filteredFastq = swapExt(fastqFile, ".fastq", ".polyATrim.adapterTrim.rmRep.fastq")
     val filteredFastqPair = swapExt(fastqPair, ".fastq", ".polyATrim.adapterTrim.rmRep.fastq")

--- a/qscripts/analyze_rna_seq.scala
+++ b/qscripts/analyze_rna_seq.scala
@@ -55,11 +55,10 @@ class AnalyzeRNASeq extends QScript {
     override def shortDescription = "MapRepetitiveRegions"
 
     var paired = noAdapterFastq != null
+    var outFastq = filteredFastq
     if (paired){
-      val outFastq = swapExt(filteredFastq, ".fastq", ".fastq").replace("1", "%")
-    } else{
-      val outFastq = filteredFastq
-    }
+      outFastq = swapExt(filteredFastq, ".fastq", ".fastq").replace("1", "%")
+    } 
 
     this.inFastq = noAdapterFastq
     this.inFastqPair = fastqPair

--- a/qscripts/analyze_rna_seq.scala
+++ b/qscripts/analyze_rna_seq.scala
@@ -324,6 +324,7 @@ class AnalyzeRNASeq extends QScript {
           // http://stackoverflow.com/questions/3348751/scala-multiple-assignment-to-existing-variable
           var filteredFastq: File = null
           var filteredFastqPair: File = null
+<<<<<<< HEAD
           if (fastqPair != null){
             if (strict) {
               var filteredFiles = stringentJobsTrimGalore(fastqFile, fastqPair, !singleEnd)
@@ -343,6 +344,27 @@ class AnalyzeRNASeq extends QScript {
                 }
             } else {
               filteredFastq = fastqFile
+=======
+          if (fastqPair == null){
+            if (strict) {
+              if (yesTrimGalore){
+                 var filteredFiles = stringentJobsTrimGalore(fastqFile, fastqPair, paired=!singleEnd)
+                 filteredFastq = filteredFiles._1
+                } else{
+                 filteredFastq = stringentJobs(fastqFile)
+                }
+            } else {
+              filteredFastq = fastqFile
+            }
+          } else {
+            if (strict) {
+              var filteredFiles = stringentJobsTrimGalore(fastqFile, fastqPair, paired=!singleEnd)
+              filteredFastq = filteredFiles._1
+              filteredFastqPair = filteredFiles._2
+            } else {
+              filteredFastq = fastqFile
+              filteredFastqPair = fastqPair
+>>>>>>> do tuple gymnastics so scala is happy
             }
           }
           samFile = swapExt(filteredFastq, ".fastq", ".sam")

--- a/qscripts/analyze_rna_seq.scala
+++ b/qscripts/analyze_rna_seq.scala
@@ -49,6 +49,7 @@ class AnalyzeRNASeq extends QScript {
     this.createIndex = true
   }
 
+<<<<<<< HEAD
   case class mapRepetitiveRegions(trimmedFastq: File, filteredResults: File, filteredFastq: File, 
     trimmedFastqPair: File = null, filteredFastqPair: File = null, dummy : File, isPaired: Boolean) extends MapRepetitiveRegions2 {
     override def shortDescription = "MapRepetitiveRegions"
@@ -66,6 +67,17 @@ class AnalyzeRNASeq extends QScript {
     this.isIntermediate = false
     this.fakeVariable = dummy
     this.paired = isPaired
+=======
+  case class mapRepetitiveRegions(noAdapterFastq: File, filteredResults: File, filteredFastq: File, 
+    fastqPair: File = null) extends MapRepetitiveRegions2 {
+    override def shortDescription = "MapRepetitiveRegions"
+
+    this.inFastq = noAdapterFastq
+    this.inFastqPair = fastqPair
+    this.outRep = filteredResults
+    this.outNoRep = filteredFastq
+    this.isIntermediate = true
+>>>>>>> MapRepetitiveRegions --> MapRepetitiveRegions2
   }
 
   case class genomeCoverageBed(input: File, outBed: File, cur_strand: String, species: String) extends GenomeCoverageBed {
@@ -196,7 +208,7 @@ class AnalyzeRNASeq extends QScript {
     val noPolyAFastq = swapExt(fastqFile, ".fastq", ".polyATrim.fastq")
     val noPolyAReport = swapExt(noPolyAFastq, ".fastq", ".metrics")
     val noAdapterFastq = swapExt(noPolyAFastq, ".fastq", ".adapterTrim.fastq")
-    val filteredFastq = swapExt(noAdapterFastq, ".fastq", ".rmRep.fastq")
+    val filteredFastq = swapExt(noAdapterFastq, ".fastq", ".rmRep.fastq").replace("R1", "R%")
     val adapterReport = swapExt(noAdapterFastq, ".fastq", ".metrics")
     val filtered_results = swapExt(filteredFastq, ".fastq", ".metrics")
     //filters out adapter reads
@@ -223,8 +235,8 @@ class AnalyzeRNASeq extends QScript {
     val trimmedFastq = outDir + "/" + swapExt(fastqFile, ".fastq", "._val_1.fq")
     val trimmedFastqPair = outDir + "/" + swapExt(fastqPair, ".fastq", "._val_2.fq")
 
-    val filteredFastq = swapExt(fastqFile, ".fastq", ".polyATrim.adapterTrim.rmRep.fastq")
-    val filteredFastqPair = swapExt(fastqPair, ".fastq", ".polyATrim.adapterTrim.rmRep.fastq")
+    val filteredFastq = swapExt(fastqFile, ".fastq", ".polyATrim.adapterTrim.rmRep.fastq").replace("R1", "R%")
+    val filteredFastqPair = swapExt(fastqFile, ".fastq", ".polyATrim.adapterTrim.rmRep.fastq").replace("R2", "R%")
 
     val filteredResults = swapExt(filteredFastq, ".fastq", ".metrics")
     val dummy: File = swapExt(fastqFile, ".fastq", ".dummy")

--- a/qscripts/analyze_rna_seq.scala
+++ b/qscripts/analyze_rna_seq.scala
@@ -51,12 +51,10 @@ class AnalyzeRNASeq extends QScript {
 
   case class mapRepetitiveRegions(noAdapterFastq: File, filteredResults: File, filteredFastq: File, 
     fastqPair: File = null, filteredFastqPair: File = null, originalFastq: File, 
-    originalFastqPair: File = null, dummy : File) extends MapRepetitiveRegions2 {
+    originalFastqPair: File = null, dummy : File, paired: Boolean) extends MapRepetitiveRegions2 {
     override def shortDescription = "MapRepetitiveRegions"
 
-    var isPaired = noAdapterFastq != null
-    var outFastq = filteredFastq
-    if (isPaired){
+    if (paired){
       outFastq = swapExt(filteredFastq, ".fastq", ".fastq").replace("1", "%")
     } 
 
@@ -64,8 +62,10 @@ class AnalyzeRNASeq extends QScript {
     this.inFastqPair = fastqPair
     this.outRepetitive = filteredResults
     this.outNoRepetitive = outFastq
+    this.outNoRepetitivePair = filteredFastqPair
     this.isIntermediate = false
     this.fakeVariable = dummy
+    this.paired = paired
   }
 
   case class genomeCoverageBed(input: File, outBed: File, cur_strand: String, species: String) extends GenomeCoverageBed {
@@ -161,7 +161,11 @@ class AnalyzeRNASeq extends QScript {
   }
 
 
+<<<<<<< HEAD
   case class trimGalore(fastqFile: File, fastqPair: File, adapter: List[String], dummy: File, isPaired: Boolean) extends TrimGalore {
+=======
+  case class trimGalore(fastqFile: File, fastqPair: File, adapter: List[String], dummy: File, paired: Boolean) extends TrimGalore {
+>>>>>>> check for paired-endness within this script and not within the TrimGalore or MapRepetitiveRegions2 scripts
     override def shortDescription = "trim_galore"
 
     this.inFastq = fastqFile
@@ -173,7 +177,11 @@ class AnalyzeRNASeq extends QScript {
     this.quality_cutoff = 6
     this.isIntermediate = true
     this.fakeVariable = dummy
+<<<<<<< HEAD
     this.paired = isPaired
+=======
+    this.paired = paired
+>>>>>>> check for paired-endness within this script and not within the TrimGalore or MapRepetitiveRegions2 scripts
   }
 
   case class makeRNASeQC(input: List[File], output: File) extends MakeRNASeQC {
@@ -206,14 +214,15 @@ class AnalyzeRNASeq extends QScript {
       adapterReport = adapterReport,
       adapter = adapter))
 
-    add(mapRepetitiveRegions(noAdapterFastq, filtered_results, filteredFastq, originalFastq=fastqFile, dummy=dummy))
+    add(mapRepetitiveRegions(noAdapterFastq, filtered_results, filteredFastq, originalFastq=fastqFile, dummy=dummy, 
+      paired=false))
     add(new FastQC(filteredFastq))
 
     return filteredFastq
   }
 
 
-  def stringentJobsTrimGalore(fastqFile: File, fastqPair: File = null): (File, File) = {
+  def stringentJobsTrimGalore(fastqFile: File, fastqPair: File = null, paired: Boolean): (File, File) = {
 
     // run if stringent
 
@@ -227,11 +236,18 @@ class AnalyzeRNASeq extends QScript {
     add(trimGalore(fastqFile = fastqFile, fastqPair=fastqPair, adapter = adapter))
 
     //filters out adapter reads
+<<<<<<< HEAD
     add(trimGalore(fastqFile, fastqPair, adapter, dummy, isPaired=paired))
 
     add(mapRepetitiveRegions(trimmedFastq=trimmedFastq, filteredResults=filteredResults, filteredFastq=filteredFastq, 
     trimmedFastqPair=trimmedFastqPair, filteredFastqPair=filteredFastqPair,
       dummy=dummy, isPaired=paired))
+=======
+    add(trimGalore(fastqFile, fastqPair, adapter, dummy, paired))
+
+    add(mapRepetitiveRegions(trimmedFastq, filtered_results, filteredFastq, trimmedFastqPair, fastqFile, fastqPair, 
+      dummy=dummy, paired))
+>>>>>>> check for paired-endness within this script and not within the TrimGalore or MapRepetitiveRegions2 scripts
 
     // Question: trim_galore can run fastqc on the 
     add(new FastQC(filteredFastq))
@@ -342,7 +358,7 @@ class AnalyzeRNASeq extends QScript {
             }
           } else {
             if (strict) {
-              var filteredFiles = stringentJobsTrimGalore(fastqFile, fastqPair)
+              var filteredFiles = stringentJobsTrimGalore(fastqFile, fastqPair, !singleEnd)
               filteredFastq = filteredFiles._1
               filteredFastqPair = filteredFiles._2
             } else {

--- a/qscripts/analyze_rna_seq.scala
+++ b/qscripts/analyze_rna_seq.scala
@@ -210,7 +210,7 @@ class AnalyzeRNASeq extends QScript {
   }
 
 
-  def stringentJobsTrimGalore(fastqFile: File, fastqPair: File = null): (File, File) = {
+  def stringentJobsTrimGalore(fastqFile: File, fastqPair: File = null, paired: Boolean = false): (File, File) = {
 
     // run if stringent
 
@@ -331,7 +331,7 @@ class AnalyzeRNASeq extends QScript {
           if (fastqPair == null){
             if (strict) {
               if (yesTrimGalore){
-                 var filteredFiles = stringentJobsTrimGalore(fastqFile, fastqPair, paired=!singleEnd)
+                 var filteredFiles = stringentJobsTrimGalore(fastqFile, paired=!singleEnd)
                  filteredFastq = filteredFiles._1
                 } else{
                  filteredFastq = stringentJobs(fastqFile)

--- a/qscripts/analyze_rna_seq.scala
+++ b/qscripts/analyze_rna_seq.scala
@@ -50,7 +50,7 @@ class AnalyzeRNASeq extends QScript {
   }
 
   case class mapRepetitiveRegions(noAdapterFastq: File, filteredResults: File, filteredFastq: File, 
-    fastqPair: File = null, originalFastq: File, originalFastqPair: File = null) extends MapRepetitiveRegions2 {
+    fastqPair: File = null, originalFastq: File, originalFastqPair: File = null, dummy : File) extends MapRepetitiveRegions2 {
     override def shortDescription = "MapRepetitiveRegions"
 
     this.inFastq = noAdapterFastq
@@ -58,6 +58,7 @@ class AnalyzeRNASeq extends QScript {
     this.outRepetitive = filteredResults
     this.outNoRepetitive = filteredFastq
     this.isIntermediate = true
+    this.dummy = dummy
   }
 
   case class genomeCoverageBed(input: File, outBed: File, cur_strand: String, species: String) extends GenomeCoverageBed {
@@ -198,8 +199,13 @@ class AnalyzeRNASeq extends QScript {
       adapterReport = adapterReport,
       adapter = adapter))
 
+<<<<<<< HEAD
     add(mapRepetitiveRegions(noAdapterFastq, filtered_results, filteredFastq, dummy=dummy, 
       isPaired=false))
+=======
+    var dummy: File = _ 
+    add(mapRepetitiveRegions(noAdapterFastq, filtered_results, filteredFastq, originalFastq=fastqFile, dummy=dummy))
+>>>>>>> add dummy variables which force dependency between trimGalore and mapRepetitiveRegions
     add(new FastQC(filteredFastq))
 
     return filteredFastq

--- a/qscripts/analyze_rna_seq.scala
+++ b/qscripts/analyze_rna_seq.scala
@@ -54,9 +54,9 @@ class AnalyzeRNASeq extends QScript {
     originalFastqPair: File = null, dummy : File) extends MapRepetitiveRegions2 {
     override def shortDescription = "MapRepetitiveRegions"
 
-    var paired = noAdapterFastq != null
+    var isPaired = noAdapterFastq != null
     var outFastq = filteredFastq
-    if (paired){
+    if (isPaired){
       outFastq = swapExt(filteredFastq, ".fastq", ".fastq").replace("1", "%")
     } 
 

--- a/qscripts/analyze_rna_seq.scala
+++ b/qscripts/analyze_rna_seq.scala
@@ -234,6 +234,7 @@ class AnalyzeRNASeq extends QScript {
     add(trimGalore(fastqFile, fastqPair, adapter, dummy, isPaired=paired))
 
     // filter out adapter reads
+    var filteredFastqPair = swapExt(fastqFile, ".fastq.gz", ".fake_fastq_pair.fastq.gz")
     if (paired){
       val trimmedFastq = swapExt(fastqFile, ".fastq.gz", "_val_1.fq")
       val trimmedFastqPair = swapExt(fastqPair, ".fastq.gz", "_val_2.fq")
@@ -242,13 +243,12 @@ class AnalyzeRNASeq extends QScript {
     trimmedFastqPair=trimmedFastqPair, filteredFastqPair=filteredFastqPair,
       dummy=dummy, isPaired=paired))
       add(new FastQC(filteredFastqPair))
-
     } else {
       val trimmedFastq = swapExt(fastqFile, ".fastq.gz", "_trimmed.fq")
       add(mapRepetitiveRegions(trimmedFastq=trimmedFastq, filteredResults=repetitiveAligned, filteredFastq=filteredFastq, 
       dummy=dummy, isPaired=paired))
       add(new FastQC(filteredFastq))
-      val filteredFastqPair = swapExt(fastqFile, ".fastq.gz", ".fake_fastq_pair.fastq.gz")
+      
     }
 
     add(countRepetitiveRegions(bam=repetitiveAligned, metrics=repetitiveCounts))

--- a/qscripts/analyze_rna_seq.scala
+++ b/qscripts/analyze_rna_seq.scala
@@ -229,7 +229,7 @@ class AnalyzeRNASeq extends QScript {
     if (fastqPair != null){
       val trimmedFastqPair = swapExt(fastqPair, ".fastq.gz", "_val_2.fq")
     } else{
-      var trimmedFastqPair: File = null
+      val trimmedFastqPair: File = null
     }
 
     val filteredFastq = swapExt(fastqFile, ".fastq", ".polyATrim.adapterTrim.rmRep.fastq")

--- a/qscripts/analyze_rna_seq.scala
+++ b/qscripts/analyze_rna_seq.scala
@@ -206,7 +206,7 @@ class AnalyzeRNASeq extends QScript {
   }
 
 
-  def stringentJobsTrimGalore(fastqFile: File, fastqPair: File = null adapter: List[String] = Nil): (File, File) = {
+  def stringentJobsTrimGalore(fastqFile: File, fastqPair: File = null, adapter: List[String] = Nil): (File, File) = {
 
     // run if stringent
 

--- a/qscripts/analyze_rna_seq.scala
+++ b/qscripts/analyze_rna_seq.scala
@@ -153,7 +153,11 @@ class AnalyzeRNASeq extends QScript {
   }
 
 
+<<<<<<< HEAD
   case class trimGalore(fastqFile: File, fastqPair: File, adapter: List[String], dummy: File, isPaired: Boolean) extends TrimGalore {
+=======
+  case class trimGalore(fastqFile: File, fastqPair: File, paired: Boolean, adapter: List[String]) extends TrimGalore {
+>>>>>>> fix up calls to trimGalore
     override def shortDescription = "trim_galore"
 
     this.inFastq = fastqFile
@@ -324,27 +328,6 @@ class AnalyzeRNASeq extends QScript {
           // http://stackoverflow.com/questions/3348751/scala-multiple-assignment-to-existing-variable
           var filteredFastq: File = null
           var filteredFastqPair: File = null
-<<<<<<< HEAD
-          if (fastqPair != null){
-            if (strict) {
-              var filteredFiles = stringentJobsTrimGalore(fastqFile, fastqPair, !singleEnd)
-              filteredFastq = filteredFiles._1
-              filteredFastqPair = filteredFiles._2
-            } else {
-              filteredFastq = fastqFile
-              filteredFastqPair = fastqPair
-            }
-          } else {
-            if (strict) {
-              if (yesTrimGalore){
-                 var filteredFiles = stringentJobsTrimGalore(fastqFile, paired=false)
-                 filteredFastq = filteredFiles._1
-                } else{
-                 filteredFastq = stringentJobs(fastqFile)
-                }
-            } else {
-              filteredFastq = fastqFile
-=======
           if (fastqPair == null){
             if (strict) {
               if (yesTrimGalore){
@@ -364,7 +347,6 @@ class AnalyzeRNASeq extends QScript {
             } else {
               filteredFastq = fastqFile
               filteredFastqPair = fastqPair
->>>>>>> do tuple gymnastics so scala is happy
             }
           }
           samFile = swapExt(filteredFastq, ".fastq", ".sam")

--- a/qscripts/analyze_rna_seq.scala
+++ b/qscripts/analyze_rna_seq.scala
@@ -227,7 +227,7 @@ class AnalyzeRNASeq extends QScript {
     val filteredFastqPair = swapExt(fastqPair, ".fastq", ".polyATrim.adapterTrim.rmRep.fastq")
 
     val repetitiveAligned = swapExt(filteredFastq, ".fastq", ".sam")
-    val repetitiveCounts = swapExt(filteredResults, ".sam", ".metrics")
+    val repetitiveCounts = swapExt(repetitiveAligned, ".sam", ".metrics")
     val dummy: File = swapExt(fastqFile, ".fastq", ".dummy")
     add(trimGalore(fastqFile = fastqFile, fastqPair=fastqPair, adapter = adapter))
 

--- a/qscripts/analyze_rna_seq.scala
+++ b/qscripts/analyze_rna_seq.scala
@@ -50,8 +50,7 @@ class AnalyzeRNASeq extends QScript {
   }
 
   case class mapRepetitiveRegions(trimmedFastq: File, filteredResults: File, filteredFastq: File, 
-    trimmedFastqPair: File = null, filteredFastqPair: File = null, originalFastq: File, 
-    originalFastqPair: File = null, dummy : File, isPaired: Boolean) extends MapRepetitiveRegions2 {
+    trimmedFastqPair: File = null, filteredFastqPair: File = null, dummy : File, isPaired: Boolean) extends MapRepetitiveRegions2 {
     override def shortDescription = "MapRepetitiveRegions"
 
     if (isPaired){
@@ -231,7 +230,8 @@ class AnalyzeRNASeq extends QScript {
     //filters out adapter reads
     add(trimGalore(fastqFile, fastqPair, adapter, dummy, isPaired=paired))
 
-    add(mapRepetitiveRegions(trimmedFastq, filteredResults, filteredFastq, trimmedFastqPair, fastqFile, fastqPair, 
+    add(mapRepetitiveRegions(trimmedFastq=trimmedFastq, filteredResults=filteredResults, filteredFastq=filteredFastq, 
+    trimmedFastqPair=trimmedFastqPair, filteredFastqPair=filteredFastqPair,
       dummy=dummy, isPaired=paired))
 
     // Question: trim_galore can run fastqc on the 

--- a/qscripts/analyze_rna_seq.scala
+++ b/qscripts/analyze_rna_seq.scala
@@ -345,7 +345,16 @@ class AnalyzeRNASeq extends QScript {
           // http://stackoverflow.com/questions/3348751/scala-multiple-assignment-to-existing-variable
           var filteredFastq: File = null
           var filteredFastqPair: File = null
-          if (fastqPair == null){
+          if (fastqPair != null){
+            if (strict) {
+              var filteredFiles = stringentJobsTrimGalore(fastqFile, fastqPair, !singleEnd)
+              filteredFastq = filteredFiles._1
+              filteredFastqPair = filteredFiles._2
+            } else {
+              filteredFastq = fastqFile
+              filteredFastqPair = fastqPair
+            }
+          } else {
             if (strict) {
               if (yesTrimGalore){
                  var filteredFiles = stringentJobsTrimGalore(fastqFile)
@@ -355,15 +364,6 @@ class AnalyzeRNASeq extends QScript {
                 }
             } else {
               filteredFastq = fastqFile
-            }
-          } else {
-            if (strict) {
-              var filteredFiles = stringentJobsTrimGalore(fastqFile, fastqPair, !singleEnd)
-              filteredFastq = filteredFiles._1
-              filteredFastqPair = filteredFiles._2
-            } else {
-              filteredFastq = fastqFile
-              filteredFastqPair = fastqPair
             }
           }
           samFile = swapExt(filteredFastq, ".fastq", ".sam")

--- a/qscripts/analyze_rna_seq.scala
+++ b/qscripts/analyze_rna_seq.scala
@@ -65,7 +65,6 @@ class AnalyzeRNASeq extends QScript {
     this.outNoRepetitivePair = filteredFastqPair
     this.isIntermediate = false
     this.fakeVariable = dummy
-    this.paired = paired
   }
 
   case class genomeCoverageBed(input: File, outBed: File, cur_strand: String, species: String) extends GenomeCoverageBed {
@@ -161,11 +160,7 @@ class AnalyzeRNASeq extends QScript {
   }
 
 
-<<<<<<< HEAD
   case class trimGalore(fastqFile: File, fastqPair: File, adapter: List[String], dummy: File, isPaired: Boolean) extends TrimGalore {
-=======
-  case class trimGalore(fastqFile: File, fastqPair: File, adapter: List[String], dummy: File, paired: Boolean) extends TrimGalore {
->>>>>>> check for paired-endness within this script and not within the TrimGalore or MapRepetitiveRegions2 scripts
     override def shortDescription = "trim_galore"
 
     this.inFastq = fastqFile
@@ -177,11 +172,7 @@ class AnalyzeRNASeq extends QScript {
     this.quality_cutoff = 6
     this.isIntermediate = true
     this.fakeVariable = dummy
-<<<<<<< HEAD
     this.paired = isPaired
-=======
-    this.paired = paired
->>>>>>> check for paired-endness within this script and not within the TrimGalore or MapRepetitiveRegions2 scripts
   }
 
   case class makeRNASeQC(input: List[File], output: File) extends MakeRNASeQC {
@@ -350,7 +341,7 @@ class AnalyzeRNASeq extends QScript {
           } else {
             if (strict) {
               if (yesTrimGalore){
-                 var filteredFiles = stringentJobsTrimGalore(fastqFile)
+                 var filteredFiles = stringentJobsTrimGalore(fastqFile, paired=false)
                  filteredFastq = filteredFiles._1
                 } else{
                  filteredFastq = stringentJobs(fastqFile)

--- a/qscripts/analyze_rna_seq.scala
+++ b/qscripts/analyze_rna_seq.scala
@@ -50,7 +50,7 @@ class AnalyzeRNASeq extends QScript {
   }
 
   case class mapRepetitiveRegions(noAdapterFastq: File, filteredResults: File, filteredFastq: File, 
-    fastqPair: File = null, originalFastqPair) extends MapRepetitiveRegions2 {
+    fastqPair: File = null, originalFastq: File = null, originalFastqPair: File = null) extends MapRepetitiveRegions2 {
     override def shortDescription = "MapRepetitiveRegions"
 
     this.inFastq = noAdapterFastq

--- a/qscripts/analyze_rna_seq.scala
+++ b/qscripts/analyze_rna_seq.scala
@@ -56,9 +56,9 @@ class AnalyzeRNASeq extends QScript {
 
     var paired = noAdapterFastq != null
     if (paired){
-      outFastq = swapExt(filteredFastq, ".fastq", ".fastq").replace("1", "%")
+      val outFastq = swapExt(filteredFastq, ".fastq", ".fastq").replace("1", "%")
     } else{
-      outFastq = filteredFastq
+      val outFastq = filteredFastq
     }
 
     this.inFastq = noAdapterFastq

--- a/qscripts/analyze_rna_seq.scala
+++ b/qscripts/analyze_rna_seq.scala
@@ -231,7 +231,7 @@ class AnalyzeRNASeq extends QScript {
     val filteredFastq = swapExt(fastqFile, ".fastq", ".polyATrim.adapterTrim.rmRep.fastq")
     val filteredFastqPair = swapExt(fastqPair, ".fastq", ".polyATrim.adapterTrim.rmRep.fastq")
 
-    val repetitiveAligned = swapExt(filteredFastq, ".fastq", ".bam")
+    val repetitiveAligned = swapExt(filteredFastq, ".fastq", "repetitiveAligned.bam")
     val repetitiveCounts = swapExt(repetitiveAligned, ".bam", ".metrics")
     val dummy: File = swapExt(fastqFile, ".fastq", ".dummy")
     add(trimGalore(fastqFile = fastqFile, fastqPair=fastqPair, adapter = adapter))

--- a/qscripts/analyze_rna_seq.scala
+++ b/qscripts/analyze_rna_seq.scala
@@ -55,8 +55,8 @@ class AnalyzeRNASeq extends QScript {
 
     this.inFastq = noAdapterFastq
     this.inFastqPair = fastqPair
-    this.outRep = filteredResults
-    this.outNoRep = filteredFastq
+    this.outRepetitive = filteredResults
+    this.outNoRepetitive = filteredFastq
     this.isIntermediate = true
   }
 

--- a/qscripts/analyze_rna_seq.scala
+++ b/qscripts/analyze_rna_seq.scala
@@ -54,7 +54,7 @@ class AnalyzeRNASeq extends QScript {
     originalFastqPair: File = null, dummy : File) extends MapRepetitiveRegions2 {
     override def shortDescription = "MapRepetitiveRegions"
 
-    var paired = inFastqPair != null
+    var paired = noAdapterFastq != null
     if (paired){
       filteredFastq = swapExt(filteredFastq, ".fastq", ".fastq").replace("1", "%")
     }

--- a/qscripts/analyze_rna_seq.scala
+++ b/qscripts/analyze_rna_seq.scala
@@ -49,25 +49,6 @@ class AnalyzeRNASeq extends QScript {
     this.createIndex = true
   }
 
-<<<<<<< HEAD
-  case class mapRepetitiveRegions(trimmedFastq: File, filteredResults: File, filteredFastq: File, 
-    trimmedFastqPair: File = null, filteredFastqPair: File = null, dummy : File, isPaired: Boolean) extends MapRepetitiveRegions2 {
-    override def shortDescription = "MapRepetitiveRegions"
-
-    if (isPaired){
-      this.outNoRepetitive = swapExt(filteredFastq, ".fastq", ".fastq").replace("_R1", "_R%")
-    } else{
-      this.outNoRepetitive = filteredFastq
-    }
-
-    this.inFastq = trimmedFastq
-    this.inFastqPair = trimmedFastqPair
-    this.outRepetitive = filteredResults
-    this.outNoRepetitivePair = filteredFastqPair
-    this.isIntermediate = false
-    this.fakeVariable = dummy
-    this.paired = isPaired
-=======
   case class mapRepetitiveRegions(noAdapterFastq: File, filteredResults: File, filteredFastq: File, 
     fastqPair: File = null) extends MapRepetitiveRegions2 {
     override def shortDescription = "MapRepetitiveRegions"
@@ -77,7 +58,6 @@ class AnalyzeRNASeq extends QScript {
     this.outRep = filteredResults
     this.outNoRep = filteredFastq
     this.isIntermediate = true
->>>>>>> MapRepetitiveRegions --> MapRepetitiveRegions2
   }
 
   case class genomeCoverageBed(input: File, outBed: File, cur_strand: String, species: String) extends GenomeCoverageBed {

--- a/qscripts/analyze_rna_seq.scala
+++ b/qscripts/analyze_rna_seq.scala
@@ -49,19 +49,19 @@ class AnalyzeRNASeq extends QScript {
     this.createIndex = true
   }
 
-  case class mapRepetitiveRegions(noAdapterFastq: File, filteredResults: File, filteredFastq: File, 
-    fastqPair: File = null, filteredFastqPair: File = null, originalFastq: File, 
+  case class mapRepetitiveRegions(trimmedFastq: File, filteredResults: File, filteredFastq: File, 
+    trimmedFastqPair: File = null, filteredFastqPair: File = null, originalFastq: File, 
     originalFastqPair: File = null, dummy : File, isPaired: Boolean) extends MapRepetitiveRegions2 {
     override def shortDescription = "MapRepetitiveRegions"
 
     if (isPaired){
-      this.outNoRepetitive = swapExt(filteredFastq, ".fastq", ".fastq").replace("1", "%")
+      this.outNoRepetitive = swapExt(filteredFastq, ".fastq", ".fastq").replace("_R1", "_R%")
     } else{
       this.outNoRepetitive = filteredFastq
     }
 
-    this.inFastq = noAdapterFastq
-    this.inFastqPair = fastqPair
+    this.inFastq = trimmedFastq
+    this.inFastqPair = trimmedFastqPair
     this.outRepetitive = filteredResults
     this.outNoRepetitivePair = filteredFastqPair
     this.isIntermediate = false

--- a/qscripts/analyze_rna_seq.scala
+++ b/qscripts/analyze_rna_seq.scala
@@ -199,7 +199,6 @@ class AnalyzeRNASeq extends QScript {
       adapterReport = adapterReport,
       adapter = adapter))
 
-
     add(mapRepetitiveRegions(noAdapterFastq, filtered_results, filteredFastq, originalFastq=fastqFile, dummy=dummy))
     add(new FastQC(filteredFastq))
 
@@ -224,7 +223,6 @@ class AnalyzeRNASeq extends QScript {
 
     //filters out adapter reads
     add(trimGalore(fastqFile, fastqPair, adapter, dummy, isPaired=paired))
-
 
     add(mapRepetitiveRegions(trimmedFastq=trimmedFastq, filteredResults=filteredResults, filteredFastq=filteredFastq, 
     trimmedFastqPair=trimmedFastqPair, filteredFastqPair=filteredFastqPair,

--- a/qscripts/analyze_rna_seq.scala
+++ b/qscripts/analyze_rna_seq.scala
@@ -58,11 +58,11 @@ class AnalyzeRNASeq extends QScript {
     } else{
       this.outNoRepetitive = filteredFastq
     }
+    this.outNoRepetitivePair = filteredFastqPair
 
     this.inFastq = trimmedFastq
     this.inFastqPair = trimmedFastqPair
     this.outRepetitive = filteredResults
-    this.outNoRepetitivePair = filteredFastqPair
     this.isIntermediate = false
     this.fakeVariable = dummy
     this.paired = isPaired
@@ -231,8 +231,8 @@ class AnalyzeRNASeq extends QScript {
     val filteredFastq = swapExt(fastqFile, ".fastq", ".polyATrim.adapterTrim.rmRep.fastq")
     val filteredFastqPair = swapExt(fastqPair, ".fastq", ".polyATrim.adapterTrim.rmRep.fastq")
 
-    val repetitiveAligned = swapExt(filteredFastq, ".fastq", ".sam")
-    val repetitiveCounts = swapExt(repetitiveAligned, ".sam", ".metrics")
+    val repetitiveAligned = swapExt(filteredFastq, ".fastq", ".bam")
+    val repetitiveCounts = swapExt(repetitiveAligned, ".bam", ".metrics")
     val dummy: File = swapExt(fastqFile, ".fastq", ".dummy")
     add(trimGalore(fastqFile = fastqFile, fastqPair=fastqPair, adapter = adapter))
 
@@ -289,16 +289,16 @@ class AnalyzeRNASeq extends QScript {
     val misoOut = swapExt(bamFile, "bam", "miso")
     val rnaEditingOut = swapExt(bamFile, "bam", "editing")
 
-    add(new CalculateNRF(inBam = bamFile, genomeSize = chromSizeLocation(species), outNRF = NRFFile))
+    // add(new CalculateNRF(inBam = bamFile, genomeSize = chromSizeLocation(species), outNRF = NRFFile))
 
     val (bigWigFilePos: File, bigWigFileNeg: File) = makeBigWig(bamFile, species = species)
 
-    add(new countTags(input = bamFile, index = bamIndex, output = countFile, species = species))
-    add(new singleRPKM(input = countFile, output = RPKMFile, s = species))
+    // add(new countTags(input = bamFile, index = bamIndex, output = countFile, species = species))
+    // add(new singleRPKM(input = countFile, output = RPKMFile, s = species))
 
     add(oldSplice(input = bamFile, out = oldSpliceOut, species = species))
     add(new Miso(inBam = bamFile, indexFile = bamIndex, species = species, pairedEnd = false, output = misoOut))
-    add(new RnaEditing(inBam = bamFile, snpEffDb = species, snpDb = snpDbLocation(species), genome = genomeLocation(species), flipped = flipped, output = rnaEditingOut))
+    // add(new RnaEditing(inBam = bamFile, snpEffDb = species, snpDb = snpDbLocation(species), genome = genomeLocation(species), flipped = flipped, output = rnaEditingOut))
     return oldSpliceOut
   }
 

--- a/qscripts/analyze_rna_seq.scala
+++ b/qscripts/analyze_rna_seq.scala
@@ -37,9 +37,22 @@ class AnalyzeRNASeq extends QScript {
   @Argument(doc = "reads are single ended", shortName = "single_end", fullName = "single_end", required = false)
   var singleEnd: Boolean = true
 
+<<<<<<< HEAD
   @Argument(doc = "Use trim_galore instead of cutadapt (required if '--strict' is provided and '--single_end' is not, i.e. for strict processing of paired-end reads)", 
     shortName = "yes_trim_galore", fullName = "yes_trim_galore", required = false)
   var yesTrimGalore: Boolean = true
+=======
+  @Argument(doc = "Use trim_galore instead of cutadapt (required if '--strict'"
+   "is provided and '--single_end' is not, i.e. for strict processing of paired-end reads)", 
+    shortName = "trim_galore", fullName = "trim_galore", required = false)
+  var trimGalore: Boolean = true
+
+  if ((trimGalore && strict) && (singleEnd == false)){
+    println("If the reads are paired-end and run with '--strict', then '--trim_galore' must be provided!\n"
+      "Otherwise your trimmed paired end reads won't retain their paired-end-ness and you'll have a bad time :(")
+    System.exit(1)
+  }
+>>>>>>> Add trimgalore
 
   case class sortSam(inSam: File, outBam: File, sortOrderP: SortOrder) extends SortSam {
     override def shortDescription = "sortSam"

--- a/qscripts/analyze_rna_seq.scala
+++ b/qscripts/analyze_rna_seq.scala
@@ -49,19 +49,19 @@ class AnalyzeRNASeq extends QScript {
     this.createIndex = true
   }
 
-  case class mapRepetitiveRegions(noAdapterFastq: File, filteredResults: File, filteredFastq: File, 
-    fastqPair: File = null, filteredFastqPair: File = null, originalFastq: File, 
+  case class mapRepetitiveRegions(trimmedFastq: File, filteredResults: File, filteredFastq: File, 
+    trimmedFastqPair: File = null, filteredFastqPair: File = null, originalFastq: File, 
     originalFastqPair: File = null, dummy : File, isPaired: Boolean) extends MapRepetitiveRegions2 {
     override def shortDescription = "MapRepetitiveRegions"
 
     if (isPaired){
-      this.outNoRepetitive = swapExt(filteredFastq, ".fastq", ".fastq").replace("1", "%")
+      this.outNoRepetitive = swapExt(filteredFastq, ".fastq", ".fastq").replace("_R1", "_R%")
     } else{
       this.outNoRepetitive = filteredFastq
     }
 
-    this.inFastq = noAdapterFastq
-    this.inFastqPair = fastqPair
+    this.inFastq = trimmedFastq
+    this.inFastqPair = trimmedFastqPair
     this.outRepetitive = filteredResults
     this.outNoRepetitivePair = filteredFastqPair
     this.isIntermediate = false
@@ -225,13 +225,13 @@ class AnalyzeRNASeq extends QScript {
     val filteredFastq = swapExt(fastqFile, ".fastq", ".polyATrim.adapterTrim.rmRep.fastq")
     val filteredFastqPair = swapExt(fastqPair, ".fastq", ".polyATrim.adapterTrim.rmRep.fastq")
 
-    val filtered_results = swapExt(filteredFastq, ".fastq", ".metrics")
+    val filteredResults = swapExt(filteredFastq, ".fastq", ".metrics")
     val dummy: File = swapExt(fastqFile, ".fastq", ".dummy")
 
     //filters out adapter reads
     add(trimGalore(fastqFile, fastqPair, adapter, dummy, isPaired=paired))
 
-    add(mapRepetitiveRegions(trimmedFastq, filtered_results, filteredFastq, trimmedFastqPair, fastqFile, fastqPair, 
+    add(mapRepetitiveRegions(trimmedFastq, filteredResults, filteredFastq, trimmedFastqPair, fastqFile, fastqPair, 
       dummy=dummy, isPaired=paired))
 
     // Question: trim_galore can run fastqc on the 

--- a/qscripts/analyze_rna_seq.scala
+++ b/qscripts/analyze_rna_seq.scala
@@ -153,11 +153,7 @@ class AnalyzeRNASeq extends QScript {
   }
 
 
-<<<<<<< HEAD
   case class trimGalore(fastqFile: File, fastqPair: File, adapter: List[String], dummy: File, isPaired: Boolean) extends TrimGalore {
-=======
-  case class trimGalore(fastqFile: File, fastqPair: File, paired: Boolean, adapter: List[String]) extends TrimGalore {
->>>>>>> fix up calls to trimGalore
     override def shortDescription = "trim_galore"
 
     this.inFastq = fastqFile
@@ -210,7 +206,7 @@ class AnalyzeRNASeq extends QScript {
   }
 
 
-  def stringentJobsTrimGalore(fastqFile: File, fastqPair: File = null, paired: Boolean = false): (File, File) = {
+  def stringentJobsTrimGalore(fastqFile: File, fastqPair: File = null adapter: List[String] = Nil): (File, File) = {
 
     // run if stringent
 
@@ -222,8 +218,14 @@ class AnalyzeRNASeq extends QScript {
     val filteredFastq = swapExt(fastqFile, ".fastq", ".polyATrim.adapterTrim.rmRep.fastq").replace("R1", "R%")
     val filteredFastqPair = swapExt(fastqFile, ".fastq", ".polyATrim.adapterTrim.rmRep.fastq").replace("R2", "R%")
 
+<<<<<<< HEAD
     val filteredResults = swapExt(filteredFastq, ".fastq", ".metrics")
     val dummy: File = swapExt(fastqFile, ".fastq", ".dummy")
+=======
+    val filtered_results = swapExt(filteredFastq, ".fastq", ".metrics")
+    //filters out adapter reads
+    add(trimGalore(fastqFile = fastqFile, fastqPair=fastqPair, adapter = adapter))
+>>>>>>> fix up call to trimgalore
 
     //filters out adapter reads
     add(trimGalore(fastqFile, fastqPair, adapter, dummy, isPaired=paired))
@@ -331,7 +333,7 @@ class AnalyzeRNASeq extends QScript {
           if (fastqPair == null){
             if (strict) {
               if (yesTrimGalore){
-                 var filteredFiles = stringentJobsTrimGalore(fastqFile, paired=!singleEnd)
+                 var filteredFiles = stringentJobsTrimGalore(fastqFile, adapter=adapter)
                  filteredFastq = filteredFiles._1
                 } else{
                  filteredFastq = stringentJobs(fastqFile)
@@ -341,7 +343,7 @@ class AnalyzeRNASeq extends QScript {
             }
           } else {
             if (strict) {
-              var filteredFiles = stringentJobsTrimGalore(fastqFile, fastqPair, paired=!singleEnd)
+              var filteredFiles = stringentJobsTrimGalore(fastqFile, fastqPair, adapter=adapter)
               filteredFastq = filteredFiles._1
               filteredFastqPair = filteredFiles._2
             } else {

--- a/qscripts/analyze_rna_seq.scala
+++ b/qscripts/analyze_rna_seq.scala
@@ -218,8 +218,8 @@ class AnalyzeRNASeq extends QScript {
 
     // run if stringent
 
-    val trimmedFastq = swapExt(fastqFile, ".fastq.gz", "_trimmed.fq")
-    val trimmedFastqPair = swapExt(fastqPair, ".fastq.gz", "_trimmed.fq")
+    val trimmedFastq = swapExt(fastqFile, ".fastq.gz", "_val_1.fq")
+    val trimmedFastqPair = swapExt(fastqPair, ".fastq.gz", "_val_2.fq")
 
     val filteredFastq = swapExt(fastqFile, ".fastq", ".polyATrim.adapterTrim.rmRep.fastq").replace("R1", "R%")
     val filteredFastqPair = swapExt(fastqFile, ".fastq", ".polyATrim.adapterTrim.rmRep.fastq").replace("R2", "R%")

--- a/qscripts/analyze_rna_seq.scala
+++ b/qscripts/analyze_rna_seq.scala
@@ -206,7 +206,7 @@ class AnalyzeRNASeq extends QScript {
       adapterReport = adapterReport,
       adapter = adapter))
 
-    add(mapRepetitiveRegions(noAdapterFastq, filtered_results, filteredFastq, originalFastq=fastqFile, dummy=dummy, 
+    add(mapRepetitiveRegions(noAdapterFastq, filtered_results, filteredFastq, dummy=dummy, 
       isPaired=false))
     add(new FastQC(filteredFastq))
 

--- a/qscripts/analyze_rna_seq.scala
+++ b/qscripts/analyze_rna_seq.scala
@@ -50,7 +50,7 @@ class AnalyzeRNASeq extends QScript {
   }
 
   case class mapRepetitiveRegions(noAdapterFastq: File, filteredResults: File, filteredFastq: File, 
-    fastqPair: File = null, originalFastq: File = null, originalFastqPair: File = null) extends MapRepetitiveRegions2 {
+    fastqPair: File = null, originalFastq: File, originalFastqPair: File = null) extends MapRepetitiveRegions2 {
     override def shortDescription = "MapRepetitiveRegions"
 
     this.inFastq = noAdapterFastq

--- a/qscripts/analyze_rna_seq.scala
+++ b/qscripts/analyze_rna_seq.scala
@@ -218,8 +218,8 @@ class AnalyzeRNASeq extends QScript {
 
     // run if stringent
 
-    val trimmedFastq = swapExt(fastqFile, ".fastq.gz", "_trimmed.fastq")
-    val trimmedFastqPair = swapExt(fastqPair, ".fastq.gz", "_trimmed.fastq")
+    val trimmedFastq = swapExt(fastqFile, ".fastq.gz", "_trimmed.fq")
+    val trimmedFastqPair = swapExt(fastqPair, ".fastq.gz", "_trimmed.fq")
 
     val filteredFastq = swapExt(fastqFile, ".fastq", ".polyATrim.adapterTrim.rmRep.fastq").replace("R1", "R%")
     val filteredFastqPair = swapExt(fastqFile, ".fastq", ".polyATrim.adapterTrim.rmRep.fastq").replace("R2", "R%")

--- a/qscripts/analyze_rna_seq.scala
+++ b/qscripts/analyze_rna_seq.scala
@@ -51,10 +51,10 @@ class AnalyzeRNASeq extends QScript {
 
   case class mapRepetitiveRegions(noAdapterFastq: File, filteredResults: File, filteredFastq: File, 
     fastqPair: File = null, filteredFastqPair: File = null, originalFastq: File, 
-    originalFastqPair: File = null, dummy : File, paired: Boolean) extends MapRepetitiveRegions2 {
+    originalFastqPair: File = null, dummy : File, isPaired: Boolean) extends MapRepetitiveRegions2 {
     override def shortDescription = "MapRepetitiveRegions"
 
-    if (paired){
+    if (isPaired){
       outFastq = swapExt(filteredFastq, ".fastq", ".fastq").replace("1", "%")
     } 
 
@@ -65,6 +65,7 @@ class AnalyzeRNASeq extends QScript {
     this.outNoRepetitivePair = filteredFastqPair
     this.isIntermediate = false
     this.fakeVariable = dummy
+    this.paired = isPaired
   }
 
   case class genomeCoverageBed(input: File, outBed: File, cur_strand: String, species: String) extends GenomeCoverageBed {
@@ -206,14 +207,14 @@ class AnalyzeRNASeq extends QScript {
       adapter = adapter))
 
     add(mapRepetitiveRegions(noAdapterFastq, filtered_results, filteredFastq, originalFastq=fastqFile, dummy=dummy, 
-      paired=false))
+      isPaired=false))
     add(new FastQC(filteredFastq))
 
     return filteredFastq
   }
 
 
-  def stringentJobsTrimGalore(fastqFile: File, fastqPair: File = null, paired: Boolean): (File, File) = {
+  def stringentJobsTrimGalore(fastqFile: File, fastqPair: File = null, paired: Boolean = false): (File, File) = {
 
     // run if stringent
 

--- a/qscripts/analyze_rna_seq.scala
+++ b/qscripts/analyze_rna_seq.scala
@@ -54,6 +54,11 @@ class AnalyzeRNASeq extends QScript {
     originalFastqPair: File = null, dummy : File) extends MapRepetitiveRegions2 {
     override def shortDescription = "MapRepetitiveRegions"
 
+    var paired = inFastqPair != null
+    if (paired){
+      filteredFastq = swapExt(filteredFastq, ".fastq", ".fastq").replace("1", "%")
+    }
+
     this.inFastq = noAdapterFastq
     this.inFastqPair = fastqPair
     this.outRepetitive = filteredResults

--- a/qscripts/analyze_rna_seq.scala
+++ b/qscripts/analyze_rna_seq.scala
@@ -236,18 +236,11 @@ class AnalyzeRNASeq extends QScript {
     add(trimGalore(fastqFile = fastqFile, fastqPair=fastqPair, adapter = adapter))
 
     //filters out adapter reads
-<<<<<<< HEAD
     add(trimGalore(fastqFile, fastqPair, adapter, dummy, isPaired=paired))
 
     add(mapRepetitiveRegions(trimmedFastq=trimmedFastq, filteredResults=filteredResults, filteredFastq=filteredFastq, 
     trimmedFastqPair=trimmedFastqPair, filteredFastqPair=filteredFastqPair,
       dummy=dummy, isPaired=paired))
-=======
-    add(trimGalore(fastqFile, fastqPair, adapter, dummy, paired))
-
-    add(mapRepetitiveRegions(trimmedFastq, filtered_results, filteredFastq, trimmedFastqPair, fastqFile, fastqPair, 
-      dummy=dummy, paired))
->>>>>>> check for paired-endness within this script and not within the TrimGalore or MapRepetitiveRegions2 scripts
 
     // Question: trim_galore can run fastqc on the 
     add(new FastQC(filteredFastq))

--- a/qscripts/analyze_rna_seq.scala
+++ b/qscripts/analyze_rna_seq.scala
@@ -50,8 +50,7 @@ class AnalyzeRNASeq extends QScript {
   }
 
   case class mapRepetitiveRegions(trimmedFastq: File, filteredResults: File, filteredFastq: File, 
-    trimmedFastqPair: File = null, filteredFastqPair: File = null, originalFastq: File, 
-    originalFastqPair: File = null, dummy : File, isPaired: Boolean) extends MapRepetitiveRegions2 {
+    trimmedFastqPair: File = null, filteredFastqPair: File = null, dummy : File, isPaired: Boolean) extends MapRepetitiveRegions2 {
     override def shortDescription = "MapRepetitiveRegions"
 
     if (isPaired){

--- a/qscripts/analyze_rna_seq.scala
+++ b/qscripts/analyze_rna_seq.scala
@@ -55,13 +55,14 @@ class AnalyzeRNASeq extends QScript {
     override def shortDescription = "MapRepetitiveRegions"
 
     if (isPaired){
-      outFastq = swapExt(filteredFastq, ".fastq", ".fastq").replace("1", "%")
-    } 
+      this.outNoRepetitive = swapExt(filteredFastq, ".fastq", ".fastq").replace("1", "%")
+    } else{
+      this.outNoRepetitive = filteredFastq
+    }
 
     this.inFastq = noAdapterFastq
     this.inFastqPair = fastqPair
     this.outRepetitive = filteredResults
-    this.outNoRepetitive = outFastq
     this.outNoRepetitivePair = filteredFastqPair
     this.isIntermediate = false
     this.fakeVariable = dummy

--- a/qscripts/analyze_rna_seq.scala
+++ b/qscripts/analyze_rna_seq.scala
@@ -50,7 +50,7 @@ class AnalyzeRNASeq extends QScript {
   }
 
   case class mapRepetitiveRegions(noAdapterFastq: File, filteredResults: File, filteredFastq: File, 
-    fastqPair: File = null) extends MapRepetitiveRegions2 {
+    fastqPair: File = null, originalFastq: File, originalFastqPair: File) extends MapRepetitiveRegions2 {
     override def shortDescription = "MapRepetitiveRegions"
 
     this.inFastq = noAdapterFastq

--- a/qscripts/analyze_rna_seq.scala
+++ b/qscripts/analyze_rna_seq.scala
@@ -199,13 +199,8 @@ class AnalyzeRNASeq extends QScript {
       adapterReport = adapterReport,
       adapter = adapter))
 
-<<<<<<< HEAD
-    add(mapRepetitiveRegions(noAdapterFastq, filtered_results, filteredFastq, dummy=dummy, 
-      isPaired=false))
-=======
-    var dummy: File = _ 
+
     add(mapRepetitiveRegions(noAdapterFastq, filtered_results, filteredFastq, originalFastq=fastqFile, dummy=dummy))
->>>>>>> add dummy variables which force dependency between trimGalore and mapRepetitiveRegions
     add(new FastQC(filteredFastq))
 
     return filteredFastq
@@ -229,6 +224,7 @@ class AnalyzeRNASeq extends QScript {
 
     //filters out adapter reads
     add(trimGalore(fastqFile, fastqPair, adapter, dummy, isPaired=paired))
+
 
     add(mapRepetitiveRegions(trimmedFastq=trimmedFastq, filteredResults=filteredResults, filteredFastq=filteredFastq, 
     trimmedFastqPair=trimmedFastqPair, filteredFastqPair=filteredFastqPair,

--- a/qscripts/analyze_rna_seq.scala
+++ b/qscripts/analyze_rna_seq.scala
@@ -247,7 +247,7 @@ class AnalyzeRNASeq extends QScript {
       add(mapRepetitiveRegions(trimmedFastq=trimmedFastq, filteredResults=repetitiveAligned, filteredFastq=filteredFastq, 
       dummy=dummy, isPaired=paired))
       add(new FastQC(filteredFastq))
-      val filteredFastq: File = null
+      val filteredFastq = swapExt(fastqFile, ".fastq.gz", ".fake_fastq_pair.fastq.gz")
     }
 
 

--- a/qscripts/analyze_rna_seq.scala
+++ b/qscripts/analyze_rna_seq.scala
@@ -234,7 +234,6 @@ class AnalyzeRNASeq extends QScript {
 
 
     return (filteredFastq, filteredFastqPair)
-
   }
 
   def makeBigWig(inBam: File, species: String): (File, File) = {


### PR DESCRIPTION
to fix this: https://github.com/YeoLab/gscripts/issues/57

should remove repetitive regions on paired-end too, so that the paired end and single end are comparable